### PR TITLE
GH-3 fixes old rust-lang-nursery links

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,7 +10,7 @@ src = "src"
 [output.html]
 curly-quotes = true
 additional-css = ["src/special-content.css"]
-git-repository-url = "https://github.com/rust-lang-nursery/cli-wg"
+git-repository-url = "https://github.com/rust-cli/book"
 
 # Linkcheck doesn't find images/SVG so it's not enabled for now
 # [output.linkcheck]

--- a/src/tutorial/README.md
+++ b/src/tutorial/README.md
@@ -78,6 +78,6 @@ Make sure you run Rust 1.31.0 (or later)
 and that you have `edition = "2018"` set
 in the `[package]` section of your `Cargo.toml` file.
 
-[Rust 2018]: https://rust-lang-nursery.github.io/edition-guide/
+[Rust 2018]: https://doc.rust-lang.org/edition-guide/index.html
 
 </aside>

--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -521,6 +521,6 @@ try to write a [fuzzer] to find bugs in edge cases.
 You can find the full, runnable source code used in this chapter
 [in this book's repository][src].
 
-[src]: https://github.com/rust-lang-nursery/cli-wg/tree/master/src/tutorial/testing
+[src]: https://github.com/rust-cli/book/tree/master/src/tutorial/testing
 
 </aside>


### PR DESCRIPTION
Fixes obvious outdated links. There's still a dead link to `rust-lang-nursery` in [`src/in-depth/machine-communication.md`](https://github.com/rust-cli/book/blame/master/src/in-depth/machine-communication.md#L259)