### PR TITLE
Adjust RUST_LOG value in logging section

### DIFF
--- a/src/tutorial/output.md
+++ b/src/tutorial/output.md
@@ -230,7 +230,7 @@ Here's a quick example:
 Assuming you have this file as `src/bin/output-log.rs`,
 on Linux and macOS, you can run it like this:
 ```console
-$ env RUST_LOG=output_log=info cargo run --bin output-log
+$ env RUST_LOG=info cargo run --bin output-log
     Finished dev [unoptimized + debuginfo] target(s) in 0.17s
      Running `target/debug/output-log`
 [2018-11-30T20:25:52Z INFO  output_log] starting up
@@ -239,7 +239,7 @@ $ env RUST_LOG=output_log=info cargo run --bin output-log
 
 In Windows PowerShell, you can run it like this:
 ```console
-$ $env:RUST_LOG="output_log=info"
+$ $env:RUST_LOG="info"
 $ cargo run --bin output-log
     Finished dev [unoptimized + debuginfo] target(s) in 0.17s
      Running `target/debug/output-log.exe`
@@ -249,7 +249,7 @@ $ cargo run --bin output-log
 
 In Windows CMD, you can run it like this:
 ```console
-$ set RUST_LOG=output_log=info
+$ set RUST_LOG=info
 $ cargo run --bin output-log
     Finished dev [unoptimized + debuginfo] target(s) in 0.17s
      Running `target/debug/output-log.exe`


### PR DESCRIPTION
If you follow the instructions on this page *to the very letter*, the example will work because the example code lives in the `output_log` module as a result of the code living in `src/bin/output-log.rs`.

However if you do anything else, such as adding logging to your `grrs` main that preceding sections had you create, you need to realize the significance of the `output_log=` and adjust in order to get any log output.

Since the material does not actually make a particular point out of configuring per-module logging, but only mentions that log messages will include the module from which message are emitted, it seems preferable to just give an examples whose `RUST_LOG` will work by default regardless of whether the reader is putting their code in the correct module. I think it will be much less likely to cause someone to wonder why they aren't seeing log messages.

Example:

```
➜  grrs git:(master) ✗ env RUST_LOG=trace cargo run -- main src/main.rs
   Compiling grrs v0.1.0 (/Users/scode/git/practice/grrs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.28s
     Running `target/debug/grrs main src/main.rs`
[2021-06-12T08:04:20Z INFO  grrs] pattern: main
[2021-06-12T08:04:20Z INFO  grrs] path: src/main.rs
fn main() -> Result<()> {
```