### PR TITLE
fix(tests): Ensure tutorial tests pass

### DIFF
--- a/src/tutorial/testing/Cargo.toml
+++ b/src/tutorial/testing/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 authors = ["Pascal Hertleif <killercup@gmail.com>"]
 edition = "2018"
 
+# Make tests work with the name used in the tutorial
+[[bin]]
+name = "grrs"
+path = "src/main.rs"
+
 [dependencies]
 structopt = "0.2.10"
 anyhow = "1.0"


### PR DESCRIPTION
Unsure how this originally passed but there is no `grrs`, so the test
fails.  The tutorial is written with that command name, so I modified
the test harness to create the executable with that name so it'd pass.