### PR TITLE
Remove outdated TODO comment

### DIFF
--- a/src/in-depth/docs.md
+++ b/src/in-depth/docs.md
@@ -4,8 +4,6 @@ Documentation for CLIs usually consists of
 a `--help` section in the command
 and a manual (`man`) page.
 
-TODO: `man` generation is being implemented with [clap-rs/clap#3174](https://github.com/clap-rs/clap/pull/3174).
-
 Both can be automatically generated
 when using `clap`, via `clap_man` crate.
 


### PR DESCRIPTION
I found an old TODO comment in the docs while going through them. I'm not sure if anything else needs to be changed in the document along with this change since I'm pretty new to Rust, but I'd be glad to fix that up if needed.