### PR TITLE
workflow: fix warning of "Node.js 12 actions are deprecated"

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,7 +10,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Spell Check Repo
       uses: crate-ci/typos@master


### PR DESCRIPTION
### Summary

This PR fixed ci warning at `book` pipeline, see: https://github.com/rust-cli/book/actions/runs/3372393190:

![image](https://user-images.githubusercontent.com/23133919/200131037-27a3023b-84ee-4e4b-b4b4-4b647a663e52.png)


