### PR TITLE
feat(tutorial): add `println!` introduction

### DIFF
--- a/src/tutorial/cli-args-struct.rs
+++ b/src/tutorial/cli-args-struct.rs
@@ -9,6 +9,8 @@ fn main() {
 
 let pattern = std::env::args().nth(1).expect("no pattern given");
 let path = std::env::args().nth(2).expect("no path given");
+println!("pattern: {}", pattern);
+println!("path: {}", path);
 let args = Cli {
     pattern: pattern,
     path: std::path::PathBuf::from(path),

--- a/src/tutorial/cli-args.md
+++ b/src/tutorial/cli-args.md
@@ -54,6 +54,29 @@ pattern: pattern
 path: path
 ```
 
+Another way to print out a value using the Debug format is to use the [dbg! macro], 
+which prints the file and line number of where that `dbg!` macro call occurs 
+in your code along with the resulting value of that expression:
+
+```rust,ignore
+let pattern = std::env::args().nth(1).expect("no pattern given");
+let path = std::env::args().nth(2).expect("no path given");
+dbg!(pattern);
+dbg!(path);
+```
+
+execute again `cargo run -- pattern path` you might see something like this:
+
+```console
+cargo run -- pattern path
+    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
+     Running `target/debug/grrs main src/main.rs`
+[src/main.rs:4] pattern = "pattern"
+[src/main.rs:5] path = "path"
+```
+
+[dbg! macro]: https://doc.rust-lang.org/std/macro.dbg.html
+
 ## CLI arguments as data type
 
 Instead of thinking about them as a bunch of text,

--- a/src/tutorial/cli-args.md
+++ b/src/tutorial/cli-args.md
@@ -35,10 +35,23 @@ the ones that follow are what the user wrote afterwards.
 [`std::env::args()`]: https://doc.rust-lang.org/1.39.0/std/env/fn.args.html
 [iterator]: https://doc.rust-lang.org/1.39.0/std/iter/index.html
 
-Getting the raw arguments this way is quite easy (in file `src/main.rs`, after `fn main() {`):
+Getting the raw arguments this way is quite easy (in file `src/main.rs`, after `fn main() {`),
+and you can use [println!] to print arguments to the standard output:
 
 ```rust,ignore
-{{#include cli-args-struct.rs:10:11}}
+{{#include cli-args-struct.rs:10:13}}
+```
+
+[println!]: https://doc.rust-lang.org/std/macro.println.html
+
+If you can execute `cargo run -- pattern path` you might see something like this:
+
+```console
+cargo run -- pattern path
+    Finished dev [unoptimized + debuginfo] target(s) in 0.80s
+     Running `target/debug/grrs pattern path`
+pattern: pattern
+path: path
 ```
 
 ## CLI arguments as data type
@@ -89,7 +102,7 @@ and build the structure ourselves.
 It would look something like this:
 
 ```rust,ignore
-{{#include cli-args-struct.rs:10:15}}
+{{#include cli-args-struct.rs:10:17}}
 ```
 
 This works, but it's not very convenient.


### PR DESCRIPTION
### Motivation

Since `println!` is used many times throughout the tutorial, it is very important to introduce `println!` in an earlier chapter, so that developers can perceive the **debuggability** of CLI programs _earlier_.