### PR TITLE
fix: Remove typo in `tutorial/testing.md`

### DIFF
--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -431,7 +431,7 @@ and create our `tests/cli.rs` file:
 
 You can run this test with
 `cargo test`,
-just the tests we wrote above.
+just like the tests we wrote above.
 It might take a little longer the first time,
 as `Command::cargo_bin("grrs")` needs to compile your main binary.
 


### PR DESCRIPTION
This fixes a small typo (adds an omitted "like") at the end of the [Testing CLI applications by running them](https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them) section to improve readability of the following sentence:

> You can run this test with `cargo test`, just the tests we wrote above.

which then becomes:
> You can run this test with `cargo test`, just like the tests we wrote above.