### PR TITLE
[Mistake, please ignore]

### DIFF
--- a/src/tutorial/testing/tests/cli.rs
+++ b/src/tutorial/testing/tests/cli.rs
@@ -9,7 +9,7 @@ fn file_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("foobar").arg("test/file/doesnt/exist");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("could not read file"));
+        .stderr(predicate::str::contains("Could not read file"));
 
     Ok(())
 }


### PR DESCRIPTION
**Update:** Sorry, my bad! I just realized that the test is matching against the custom anyhow error, that has been defined in `main.rs`. I diverged from the tutorial's capitalization in my code and only realized it now.

Fixes the `file_doesnt_exist` test, which fails with latest rustc due to a mismatch in capitalization. It seems like the CI tests on this repo utilize an outdate rustc version:

https://github.com/rust-cli/book/actions/runs/5193164845/jobs/9363445982?pr=221#step:3:13
```
rustc 1.69.0 (84c898d65 2023-04-16)
```

Rust generates the following error for this test with a capital `C`:
```
Error: Could not read file \'test/file/doesnt/exist\'
```

while the test is looking for a match against the string `"could not read file"`, with a minuscule `c`.

# Tests

```
❯ rustup --version
rustup 1.26.0 (5af9b9484 2023-04-05)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.70.0 (90c541806 2023-05-31)`

❯ rustup toolchain list
stable-x86_64-unknown-linux-gnu (default)
```

## Before fix:
![image](https://github.com/rust-cli/book/assets/9947384/6b9962ed-2b9d-4995-8f9d-e5f977e06f84)

## After fix:
![image](https://github.com/rust-cli/book/assets/9947384/9b8f3b84-04b5-4f6f-86f4-b5bcf8ff03be)

PS: Thank you for this awesome resource!
