### PR TITLE
Improve code examples in args parsing chapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Pascal Hertleif <killercup@gmail.com>"]
 edition = "2018"
 
 [[bin]]
+name = "cli-args-vars"
+path = "src/tutorial/cli-args-vars.rs"
+
+[[bin]]
 name = "cli-args-struct"
 path = "src/tutorial/cli-args-struct.rs"
 

--- a/src/tutorial/cli-args-struct.rs
+++ b/src/tutorial/cli-args-struct.rs
@@ -6,12 +6,11 @@ struct Cli {
 }
 
 fn main() {
+    let pattern = std::env::args().nth(1).expect("no pattern given");
+    let path = std::env::args().nth(2).expect("no path given");
 
-let pattern = std::env::args().nth(1).expect("no pattern given");
-let path = std::env::args().nth(2).expect("no path given");
-let args = Cli {
-    pattern: pattern,
-    path: std::path::PathBuf::from(path),
-};
-
+    let args = Cli {
+        pattern: pattern,
+        path: std::path::PathBuf::from(path),
+    };
 }

--- a/src/tutorial/cli-args-vars.rs
+++ b/src/tutorial/cli-args-vars.rs
@@ -1,0 +1,6 @@
+#![allow(unused)]
+
+fn main() {
+    let pattern = std::env::args().nth(1).expect("no pattern given");
+    let path = std::env::args().nth(2).expect("no path given");
+}

--- a/src/tutorial/cli-args.md
+++ b/src/tutorial/cli-args.md
@@ -65,7 +65,7 @@ way of looking at CLI arguments fits very well. Let's start with this (in file
 `src/main.rs`, before `fn main() {`):
 
 ```rust,ignore
-{{#include cli-args-struct.rs:3:7}}
+{{#include cli-args-struct.rs:3:6}}
 ```
 
 This defines a new structure (a [`struct`])
@@ -89,7 +89,7 @@ and build the structure ourselves.
 It would look something like this:
 
 ```rust,ignore
-{{#include cli-args-struct.rs:10:15}}
+{{#include cli-args-struct.rs:8:16}}
 ```
 
 This works, but it's not very convenient.

--- a/src/tutorial/cli-args.md
+++ b/src/tutorial/cli-args.md
@@ -35,10 +35,10 @@ the ones that follow are what the user wrote afterwards.
 [`std::env::args()`]: https://doc.rust-lang.org/1.39.0/std/env/fn.args.html
 [iterator]: https://doc.rust-lang.org/1.39.0/std/iter/index.html
 
-Getting the raw arguments this way is quite easy (in file `src/main.rs`, after `fn main() {`):
+Getting the raw arguments this way is quite easy (in file `src/main.rs`):
 
 ```rust,ignore
-{{#include cli-args-struct.rs:10:11}}
+{{#include cli-args-vars.rs:3:6}}
 ```
 
 ## CLI arguments as data type


### PR DESCRIPTION
This adds more context to some examples in the "Parsing command line arguments" chapter.