### PR TITLE
Add `grss` implementation to errors chapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ name = "errors-exit"
 path = "src/tutorial/errors-exit.rs"
 
 [[bin]]
+name = "errors-impl"
+path = "src/tutorial/errors-impl.rs"
+
+[[bin]]
 name = "output-progressbar"
 path = "src/tutorial/output-progressbar.rs"
 

--- a/src/tutorial/errors-impl.rs
+++ b/src/tutorial/errors-impl.rs
@@ -1,0 +1,26 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+
+/// Search for a pattern in a file and display the lines that contain it.
+#[derive(Parser)]
+struct Cli {
+    /// The pattern to look for
+    pattern: String,
+    /// The path to the file to read
+    path: std::path::PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Cli::parse();
+
+    let content = std::fs::read_to_string(&args.path)
+        .with_context(|| format!("could not read file `{}`", args.path.display()))?;
+
+    for line in content.lines() {
+        if line.contains(&args.pattern) {
+            println!("{}", line);
+        }
+    }
+
+    Ok(())
+}

--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -233,3 +233,12 @@ Error: could not read file `test.txt`
 Caused by:
     No such file or directory (os error 2)
 ```
+
+## Wrapping up
+
+The complete code for our `grrs` tool with improved error reporting
+will look like this:
+
+```rust,ignore
+{{#include errors-impl.rs}}
+```

--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -236,8 +236,7 @@ Caused by:
 
 ## Wrapping up
 
-The complete code for our `grrs` tool with improved error reporting
-will look like this:
+Your code should now look like:
 
 ```rust,ignore
 {{#include errors-impl.rs}}


### PR DESCRIPTION
At the end of the chapter, provide a running code example that applies the nicer error reporting to the `grrs` tool.