### PR TITLE
Add instructions on how to build the book

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,32 @@
 This repo contains the CLAiR, the [Command Line Applications in Rust][clair] book.
 It is written and updated by the [Rust CLI working group][wg].
 
+## Building
+
+Building the book requires [mdBook].
+To get it:
+
+[mdBook]: https://github.com/rust-lang/mdBook
+
+```bash
+$ cargo install mdbook
+```
+
+To build the book, type:
+
+```bash
+$ mdbook build
+```
+
+The output will be in the `book` subdirectory.
+To check it out, open `book/index.html` in your web browser.
+
+To run the tests:
+
+```bash
+$ mdbook test
+```
+
 ## Multi-language support
 Unofficial translation:
 - 中文(zh_CN)：[Rust 中的命令行应用][rust-cli-zh_CN] (2021-09-13)


### PR DESCRIPTION
The instructions are adopted from the [Readme of the Rust book repo](https://github.com/stomar/rust-book/blob/main/README.md).

I dropped the note on the recommended mdBook version because I do not know whether it applies here.