### PR TITLE
Specify directories for test files in testing.md

### DIFF
--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -56,7 +56,7 @@ fn check_answer_validity() {
 }
 ```
 
-You can put this snippet of code in pretty much any file
+You can put this snippet of code in pretty much any file in `src/` or `tests/`
 and `cargo test` will find
 and run it.
 The key here is the `#[test]` attribute.


### PR DESCRIPTION
The current wording might suggest, any arbitrary location for test files.
But, cargo limits it's search to `src/` and `test/`

See the [cargo docs](https://github.com/rust-lang/cargo/blob/master/src/doc/src/guide/tests.md)