### PR TITLE
Fix: Use cargo_bin_cmd instead of deprecated Command::cargo_bin

### DIFF
--- a/src/tutorial/testing/tests/cli.rs
+++ b/src/tutorial/testing/tests/cli.rs
@@ -1,10 +1,9 @@
-use assert_cmd::prelude::*; // Add methods on commands
+use assert_cmd::cargo::*; // Import cargo_bin_cmd! macro and methods
 use predicates::prelude::*; // Used for writing assertions
-use std::process::Command; // Run programs
 
 #[test]
 fn file_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("grrs")?;
+    let mut cmd = cargo_bin_cmd!("grrs");
 
     cmd.arg("foobar").arg("test/file/doesnt/exist");
     cmd.assert()
@@ -21,7 +20,7 @@ fn find_content_in_file() -> Result<(), Box<dyn std::error::Error>> {
     let file = assert_fs::NamedTempFile::new("sample.txt")?;
     file.write_str("A test\nActual content\nMore content\nAnother test")?;
 
-    let mut cmd = Command::cargo_bin("grrs")?;
+    let mut cmd = cargo_bin_cmd!("grrs");
     cmd.arg("test").arg(file.path());
     cmd.assert()
         .success()


### PR DESCRIPTION
Hi, I noticed that `Command::cargo_bin` (from `assert_cmd::prelude::CommandCargoExt`) is deprecated in `assert_cmd`.
This PR updates the sample code in `src/tutorial/testing/tests/cli.rs` to use the recommended `assert_cmd::cargo::cargo_bin_cmd` function instead.

### Changes:
- Import `assert_cmd::cargo::*`.
- Remove the `use std::process::Command;` (no longer necessary for creating `cmd`).
- Replace `Command::cargo_bin("grrs")?` with `cargo_bin_cmd!("grrs")`.
